### PR TITLE
add paragraph in documentation that explains why Time::HiRes::time shoul...

### DIFF
--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -2528,6 +2528,15 @@ with C<Time::HiRes>. If the floating portion extends past 9 decimal
 places, it will be truncated to nine, so that 1.1234567891 will become
 1 second and 123,456,789 nanoseconds.
 
+If you pass the value from C<Time::HiRes::time>, please be aware that
+C<time> returns only 15 digits by default, so that the floating point
+portion has only 5 digits since 2001. If you want to have nanoseconds
+with C<Time::HiRes>, you have to use
+
+  DateTime->from_epoch( epoch => sprintf( "%.9f", Time::HiRes::time ), ... );
+
+See Note 2 in L<Time::HiRes::time|Time::HiRes/time> for more information.
+
 By default, the returned object will be in the UTC time zone.
 
 =head3 DateTime->now( ... )


### PR DESCRIPTION
...d be sprintf'ed for from_epoche

time returns 15 digits by default. So the floating point portion can't have 9 digits (as needed for nanoseconds). The solution is to
use sprintf.