### PR TITLE
Fixes a problem where comparing undef to a DateTime object using an over...

### DIFF
--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -1828,7 +1828,13 @@ sub _compare_overload {
 
     # note: $_[1]->compare( $_[0] ) is an error when $_[1] is not a
     # DateTime (such as the INFINITY value)
-    return $_[2] ? -$_[0]->compare( $_[1] ) : $_[0]->compare( $_[1] );
+
+    if ( defined $_[0] && defined $_[1] ) {
+        return $_[2] ? -$_[0]->compare( $_[1] ) : $_[0]->compare( $_[1] );
+    }
+    else {
+        return $_[2] ? $_[0]->compare( $_[1] ) : $_[0]->compare( $_[1] );
+    }
 }
 
 sub _string_compare_overload {

--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -1829,12 +1829,9 @@ sub _compare_overload {
     # note: $_[1]->compare( $_[0] ) is an error when $_[1] is not a
     # DateTime (such as the INFINITY value)
 
-    if ( defined $_[0] && defined $_[1] ) {
-        return $_[2] ? -$_[0]->compare( $_[1] ) : $_[0]->compare( $_[1] );
-    }
-    else {
-        return $_[2] ? $_[0]->compare( $_[1] ) : $_[0]->compare( $_[1] );
-    }
+    return undef unless defined $_[1];
+
+    return $_[2] ? -$_[0]->compare( $_[1] ) : $_[0]->compare( $_[1] );
 }
 
 sub _string_compare_overload {

--- a/t/29overload.t
+++ b/t/29overload.t
@@ -110,6 +110,16 @@ use DateTime;
         'Cannot compare a DateTime object to a FooBar object'
     );
 
+    my $saw_undef_cmp_warning = 0;
+    $SIG{__WARN__} =
+        sub { $saw_undef_cmp_warning = 1 if $_[0] =~ /uninitialized value in numeric/ };
+    { my $x = undef > $dt; }
+    $SIG{__WARN__} = undef;
+    ok(
+        $saw_undef_cmp_warning,
+        'Comparing undef to a DateTime object generates a Perl warning'
+    );
+
     ok(
         !( $dt eq 'some string' ),
         'DateTime object always compares false to a string'

--- a/t/29overload.t
+++ b/t/29overload.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 
 use Test::More;
+use Test::Warnings 0.005 ':all';
 
 use DateTime;
 
@@ -110,13 +111,9 @@ use DateTime;
         'Cannot compare a DateTime object to a FooBar object'
     );
 
-    my $saw_undef_cmp_warning = 0;
-    $SIG{__WARN__} =
-        sub { $saw_undef_cmp_warning = 1 if $_[0] =~ /uninitialized value in numeric/ };
-    { my $x = undef > $dt; }
-    $SIG{__WARN__} = undef;
-    ok(
-        $saw_undef_cmp_warning,
+    like(
+        warning { my $x = undef > $dt; },
+        qr/uninitialized value in numeric/,
         'Comparing undef to a DateTime object generates a Perl warning'
     );
 


### PR DESCRIPTION
...loaded comparison operator (e.g. $blank = undef; $now = DateTime->now; $result = $blank < $now;) would result Perl printing a warning about negating an undefined value (and pointing at a line inside of DateTime.pm) versus a more typical warning about comparing against undef (and pointing at the line of code actually making the comparison).