### PR TITLE
Fixes a problem where comparing undef to a DateTime object using an over...

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 {{$NEXT}}
 
+- If you compared a DateTime object to an undef value, you might have received
+  a warning pointing to code inside DateTime.pm, instead of in your own
+  code. Fixed by Jason McIntosh. GH #7.
+
+
 1.18   2015-01-05
 
 - There will be a new leap second on June 30, 2015.

--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -1801,6 +1801,9 @@ sub _compare_overload {
 
     # note: $_[1]->compare( $_[0] ) is an error when $_[1] is not a
     # DateTime (such as the INFINITY value)
+
+    return undef unless defined $_[1];
+
     return $_[2] ? -$_[0]->compare( $_[1] ) : $_[0]->compare( $_[1] );
 }
 

--- a/t/29overload.t
+++ b/t/29overload.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 
 use Test::More;
+use Test::Warnings 0.005 ':all';
 
 use DateTime;
 
@@ -108,6 +109,18 @@ use DateTime;
         $@,
         qr/A DateTime object can only be compared to another DateTime object/,
         'Cannot compare a DateTime object to a FooBar object'
+    );
+
+    like(
+        warning { my $x = undef; $dt > $x; },
+        qr/uninitialized value in numeric gt .+ at .*t.(release-pp-)?29overload\.t/,
+        'Comparing undef to a DateTime object generates a Perl warning at the right spot ($dt > undef)'
+    );
+
+    like(
+        warning { my $x = undef; $x > $dt; },
+        qr/uninitialized value in numeric gt .+ at .*t.(release-pp-)?29overload\.t/,
+        'Comparing undef to a DateTime object generates a Perl warning at the right spot (undef > $dt)'
     );
 
     ok(


### PR DESCRIPTION
...loaded comparison operator

For example, `$blank = undef; $now = DateTime->now; $result = $blank < $now;` would result Perl printing a warning about negating an undefined value (and pointing at a line inside of DateTime.pm) versus a more typical warning about comparing against undef (and pointing at the line of code actually making the comparison).