### PR TITLE
Treat floating-point epoch values as floating-point values

### DIFF
--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -2513,7 +2513,7 @@ This class method can be used to construct a new DateTime object from
 an epoch time instead of components. Just as with the C<new()>
 method, it accepts "time_zone", "locale", and "formatter" parameters.
 
-If the epoch value is a floting-point value, it will be rounded to
+If the epoch value is a floating-point value, it will be rounded to
 nearest microsecond.
 
 By default, the returned object will be in the UTC time zone.

--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -476,7 +476,7 @@ sub _calc_local_components {
          ^ -? (?: [0-9]+ (?: \.[0-9]*)? | \. [0-9]+) (?: [eE][+-]?[0-9]+)? $
     /x;
     my $spec = {
-        epoch     => { regex => $float                         },
+        epoch     => { regex => $float },
         locale    => { type  => SCALAR | OBJECT, optional => 1 },
         language  => { type  => SCALAR | OBJECT, optional => 1 },
         time_zone => { type  => SCALAR | OBJECT, optional => 1 },
@@ -491,22 +491,22 @@ sub _calc_local_components {
         my %p = validate( @_, $spec );
 
         my %args;
-        if ($p{epoch} =~ /[.eE]/) {
-            my ($f, $n, $s);
+        if ( $p{epoch} =~ /[.eE]/ ) {
+            my ( $f, $n, $s );
 
-            $f = $n = fmod($p{epoch}, 1.0);
-            $s = floor($p{epoch} - $f);
-            if ($n < 0) {
+            $f = $n = fmod( $p{epoch}, 1.0 );
+            $s = floor( $p{epoch} - $f );
+            if ( $n < 0 ) {
                 $n += 1;
             }
-            $p{epoch} = $s + floor($f - $n);
-            $args{nanosecond} = floor($n * 1E6 + 0.5) * 1E3;
+            $p{epoch}         = $s + floor( $f - $n );
+            $args{nanosecond} = floor( $n * 1E6 + 0.5 ) * 1E3;
         }
 
         # Note, for very large negative values this may give a
         # blatantly wrong answer.
         @args{qw( second minute hour day month year )}
-            = ( gmtime($p{epoch}) )[ 0 .. 5 ];
+            = ( gmtime( $p{epoch} ) )[ 0 .. 5 ];
         $args{year} += 1900;
         $args{month}++;
 

--- a/t/04epoch.t
+++ b/t/04epoch.t
@@ -128,7 +128,7 @@ use DateTime;
 
 {
     my $dt = DateTime->from_epoch( epoch => 0.1234567891 );
-    is( $dt->nanosecond, 123_456_789, 'nanosecond should be an integer ' );
+    is( $dt->nanosecond, 123_457_000, 'nanosecond should be an integer ' );
 }
 
 {

--- a/t/04epoch.t
+++ b/t/04epoch.t
@@ -116,6 +116,17 @@ use DateTime;
 }
 
 {
+    my $dt = DateTime->from_epoch( epoch => -0.5 );
+    is(
+        $dt->nanosecond, 500_000_000,
+        'nanosecond should be 500,000,000 with 0.5 as epoch'
+    );
+
+    is( $dt->epoch,       -1,   'epoch should be -1' );
+    is( $dt->hires_epoch, -0.5, 'hires_epoch should be -0.5' );
+}
+
+{
     my $dt = DateTime->from_epoch( epoch => 0.1234567891 );
     is( $dt->nanosecond, 123_456_789, 'nanosecond should be an integer ' );
 }

--- a/t/04epoch.t
+++ b/t/04epoch.t
@@ -119,7 +119,7 @@ use DateTime;
     my $dt = DateTime->from_epoch( epoch => -0.5 );
     is(
         $dt->nanosecond, 500_000_000,
-        'nanosecond should be 500,000,000 with 0.5 as epoch'
+        'nanosecond should be 500,000,000 with -0.5 as epoch'
     );
 
     is( $dt->epoch,       -1,   'epoch should be -1' );


### PR DESCRIPTION
This pull request fixes a bug when ->from_epoch is invoked negative fractional seconds, It also changes the way ->from_epoch handles floating-point epoch values. 