### PR TITLE
Add JSON hook to auto-stringify DateTime objects during JSON encoding.

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -19,7 +19,7 @@ my %module_build_args = (
     "Dave Rolsky <autarch\@urth.org>"
   ],
   "dist_name" => "DateTime",
-  "dist_version" => "1.21",
+  "dist_version" => "1.22",
   "license" => "artistic_2",
   "module_name" => "DateTime",
   "recursive_test_files" => 1,
@@ -27,6 +27,7 @@ my %module_build_args = (
     "Carp" => 0,
     "DateTime::Locale" => "0.41",
     "DateTime::TimeZone" => "1.74",
+    "JSON::PP" => "2.27300",
     "POSIX" => 0,
     "Params::Validate" => "1.03",
     "Scalar::Util" => 0,

--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 {{$NEXT}}
 
+- Add hook for automatically returning the stringified version of the current
+  DateTime object when being encoded using the JSON module.
+
+
 1.21   2015-09-30
 
 - Make all tests pass with both the current DateTime::Locale and the upcoming

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-This software is Copyright (c) 2015 by Dave Rolsky.
+This software is Copyright (c) 2016 by Dave Rolsky.
 
 This is free software, licensed under:
 

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,7 @@
 requires "Carp" => "0";
 requires "DateTime::Locale" => "0.41";
 requires "DateTime::TimeZone" => "1.74";
+requires "JSON::PP" => "2.27300";
 requires "POSIX" => "0";
 requires "Params::Validate" => "1.03";
 requires "Scalar::Util" => "0";

--- a/dist.ini
+++ b/dist.ini
@@ -20,6 +20,7 @@ pod_coverage_skip = DateTime::PP
 pod_coverage_skip = DateTime::PPExtra
 pod_coverage_trustme = DateTime => qr/0$/
 pod_coverage_trustme = DateTime => qr/^STORABLE/
+pod_coverage_trustme = DateTime => qr/^TO_JSON/
 pod_coverage_trustme = DateTime => qr/^utc_year$/
 pod_coverage_trustme = DateTime => qr/^timegm$/
 pod_coverage_trustme = DateTime => qr/^day_of_month$/

--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -3685,7 +3685,7 @@ Stringification> for details.
 You can optionally specify a "formatter", which is usually a
 DateTime::Format::* object/class, to control the stringification of
 the DateTime object. Stringification will occur when a DateTime object
-is concated, used in string context or serialized.
+is concatenated, used in string context or serialized.
 
 Any of the constructor methods can accept a formatter argument:
 

--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -2130,6 +2130,11 @@ sub STORABLE_thaw {
     return $self;
 }
 
+sub TO_JSON {
+    my $self = shift;
+    return $self->_stringify;
+}
+
 package    # hide from PAUSE
     DateTime::_Thawed;
 
@@ -3679,7 +3684,8 @@ Stringification> for details.
 
 You can optionally specify a "formatter", which is usually a
 DateTime::Format::* object/class, to control the stringification of
-the DateTime object.
+the DateTime object. Stringification will occur when a DateTime object
+is concated, used in string context or serialized.
 
 Any of the constructor methods can accept a formatter argument:
 
@@ -4236,6 +4242,13 @@ where "method" is a valid C<DateTime.pm> object method.
 
 DateTime implements Storable hooks in order to reduce the size of a
 serialized DateTime object.
+
+=head2 DateTime.pm and JSON
+
+DateTime implements L<JSON> hooks: Any DateTime object passed to I<encode_json>
+or I<to_json> will be stringified using the current formatter (see
+L<Formatters And Stringification>) if I<convert_blessed> is true. See
+the L<JSON> module for details.
 
 =head1 THE DATETIME PROJECT ECOSYSTEM
 

--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -548,8 +548,8 @@ sub today { shift->now(@_)->truncate( to => 'day' ) }
             type => OBJECT,
             can  => 'utc_rd_values',
         },
-        locale    => { type => SCALAR | OBJECT, optional => 1 },
-        language  => { type => SCALAR | OBJECT, optional => 1 },
+        locale   => { type => SCALAR | OBJECT, optional => 1 },
+        language => { type => SCALAR | OBJECT, optional => 1 },
         formatter => {
             type     => SCALAR | OBJECT, can => 'format_datetime',
             optional => 1
@@ -1115,7 +1115,7 @@ sub jd { $_[0]->mjd + 2_400_000.5 }
             $y2 *= -1 if $year < 0;
             $_[0]->_zero_padded_number( 'yy', $y2 );
         },
-        qr/y/    => sub { $_[0]->year() },
+        qr/y/ => sub { $_[0]->year() },
         qr/(u+)/ => sub { $_[0]->_zero_padded_number( $1, $_[0]->year() ) },
         qr/(Y+)/ =>
             sub { $_[0]->_zero_padded_number( $1, $_[0]->week_year() ) },
@@ -1164,7 +1164,7 @@ sub jd { $_[0]->mjd + 2_400_000.5 }
         qr/(D{1,3})/ =>
             sub { $_[0]->_zero_padded_number( $1, $_[0]->day_of_year() ) },
 
-        qr/F/    => 'weekday_of_month',
+        qr/F/ => 'weekday_of_month',
         qr/(g+)/ => sub { $_[0]->_zero_padded_number( $1, $_[0]->mjd() ) },
 
         qr/EEEEE/ => sub {

--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -548,8 +548,8 @@ sub today { shift->now(@_)->truncate( to => 'day' ) }
             type => OBJECT,
             can  => 'utc_rd_values',
         },
-        locale   => { type => SCALAR | OBJECT, optional => 1 },
-        language => { type => SCALAR | OBJECT, optional => 1 },
+        locale    => { type => SCALAR | OBJECT, optional => 1 },
+        language  => { type => SCALAR | OBJECT, optional => 1 },
         formatter => {
             type     => SCALAR | OBJECT, can => 'format_datetime',
             optional => 1
@@ -1115,7 +1115,7 @@ sub jd { $_[0]->mjd + 2_400_000.5 }
             $y2 *= -1 if $year < 0;
             $_[0]->_zero_padded_number( 'yy', $y2 );
         },
-        qr/y/ => sub { $_[0]->year() },
+        qr/y/    => sub { $_[0]->year() },
         qr/(u+)/ => sub { $_[0]->_zero_padded_number( $1, $_[0]->year() ) },
         qr/(Y+)/ =>
             sub { $_[0]->_zero_padded_number( $1, $_[0]->week_year() ) },
@@ -1164,7 +1164,7 @@ sub jd { $_[0]->mjd + 2_400_000.5 }
         qr/(D{1,3})/ =>
             sub { $_[0]->_zero_padded_number( $1, $_[0]->day_of_year() ) },
 
-        qr/F/ => 'weekday_of_month',
+        qr/F/    => 'weekday_of_month',
         qr/(g+)/ => sub { $_[0]->_zero_padded_number( $1, $_[0]->mjd() ) },
 
         qr/EEEEE/ => sub {

--- a/t/47json.t
+++ b/t/47json.t
@@ -6,22 +6,34 @@ use Test::More tests => 3;
 
 use_ok('DateTime');
 
-note($INC{"DateTime.pm"});
+note( $INC{"DateTime.pm"} );
 
 SKIP: {
-    skip 'This test requires the JSON module to be installed',3
+    skip 'This test requires the JSON module to be installed', 2
         unless eval 'use JSON qw(to_json); return 1;';
 
-    is(to_json([DateTime->new(
-        year      => 2016,
-        month     => 1,
-        day       => 20,
-        hour      => 20,
-        minute    => 30,
-        second    => 40,
-        time_zone => 'UTC',
-    )], {convert_blessed => 1}),'["2016-01-20T20:30:40"]','to_json fixed date');
+    is(
+        to_json(
+            [
+                DateTime->new(
+                    year      => 2016,
+                    month     => 1,
+                    day       => 20,
+                    hour      => 20,
+                    minute    => 30,
+                    second    => 40,
+                    time_zone => 'UTC',
+                )
+            ],
+            { convert_blessed => 1 }
+        ),
+        '["2016-01-20T20:30:40"]',
+        'to_json fixed date'
+    );
 
     my $dt = DateTime->now;
-    is(to_json([$dt], {convert_blessed => 1}),'["'.$dt->iso8601.'"]','to_json now');
+    is(
+        to_json( [$dt], { convert_blessed => 1 } ),
+        '["' . $dt->iso8601 . '"]', 'to_json now'
+    );
 }

--- a/t/47json.t
+++ b/t/47json.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+
+use Test::Fatal;
+use Test::More tests => 3;
+
+use_ok('DateTime');
+
+note($INC{"DateTime.pm"});
+
+SKIP: {
+    skip 'This test requires the JSON module to be installed',3
+        unless eval 'use JSON qw(to_json); return 1;';
+
+    is(to_json([DateTime->new(
+        year      => 2016,
+        month     => 1,
+        day       => 20,
+        hour      => 20,
+        minute    => 30,
+        second    => 40,
+        time_zone => 'UTC',
+    )], {convert_blessed => 1}),'["2016-01-20T20:30:40"]','to_json fixed date');
+
+    my $dt = DateTime->now;
+    is(to_json([$dt], {convert_blessed => 1}),'["'.$dt->iso8601.'"]','to_json now');
+}


### PR DESCRIPTION
JSON is heavily used with NoSQL databases like MongoDB or Elasticsearch and even more with Ajax requests.
Any DateTime object currently triggers a fatal error *encountered object '2016-01-20T20:30:40', but neither allow_blessed, convert_blessed nor allow_tags settings are enabled (or TO_JSON/FREEZE method missing) at /usr/share/perl5/JSON.pm line 154.* This error message is very tricky, because it contains the stringified version of the DateTime object and people don't easily understand why a string caused this error.
This patch adds a TO_JSON method to DateTime which stringifies during JSON encoding if the JSON argument *convert_blessed* has been enabled. Doesn't change the current behavior if *convert_blessed* isn't enabled.
