### PR TITLE
Add default time zone support via an environment variable.

### DIFF
--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -187,8 +187,8 @@ my $BasicValidate = {
 my $NewValidate = {
     %$BasicValidate,
     time_zone => {
-        type    => SCALAR | OBJECT,
-        default => 'floating'
+        type     => SCALAR | OBJECT,
+        optional => 1,
     },
 };
 
@@ -213,14 +213,14 @@ sub _new {
         if ref $class;
 
     # If this method is called from somewhere other than new(), then some of
-    # these default may not get applied.
-    $p{month}      = 1          unless exists $p{month};
-    $p{day}        = 1          unless exists $p{day};
-    $p{hour}       = 0          unless exists $p{hour};
-    $p{minute}     = 0          unless exists $p{minute};
-    $p{second}     = 0          unless exists $p{second};
-    $p{nanosecond} = 0          unless exists $p{nanosecond};
-    $p{time_zone}  = 'floating' unless exists $p{time_zone};
+    # these defaults may not get applied.
+    $p{month}      = 1                          unless exists $p{month};
+    $p{day}        = 1                          unless exists $p{day};
+    $p{hour}       = 0                          unless exists $p{hour};
+    $p{minute}     = 0                          unless exists $p{minute};
+    $p{second}     = 0                          unless exists $p{second};
+    $p{nanosecond} = 0                          unless exists $p{nanosecond};
+    $p{time_zone}  = $class->_default_time_zone unless exists $p{time_zone};
 
     my $self = bless {}, $class;
 
@@ -279,6 +279,13 @@ sub _new {
     }
 
     return $self;
+}
+
+# Warning: do not use this environment variable unless you have no choice in
+# the matter.
+sub _default_time_zone {
+    my $class = shift;
+    return $ENV{DEFAULT_DATETIME_TZ} || 'floating';
 }
 
 sub _set_locale {
@@ -622,7 +629,7 @@ sub today { shift->now(@_)->truncate( to => 'day' ) }
             $new->set_time_zone( $object->time_zone );
         }
         else {
-            $new->set_time_zone('floating');
+            $new->set_time_zone( $class->_default_time_zone );
         }
 
         return $new;

--- a/t/47default-time-zone.t
+++ b/t/47default-time-zone.t
@@ -1,0 +1,68 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use DateTime;
+
+my $dt = DateTime->new( year => 2000, month => 2, day => 21 );
+is( $dt->time_zone->name, 'floating',
+    'Time zones for new DateTime objects should default to floating'
+);
+is( DateTime->last_day_of_month( year => 2000, month => 2 )->time_zone->name,
+    'floating',
+    'last_day_of_month time zone also should default to floating'
+);
+is( DateTime->from_day_of_year( year => 2000, day_of_year => 212 )
+      ->time_zone->name,
+    'floating',
+    'from_day_of_year time zone also should default to floating'
+);
+is( DateTime->now->time_zone->name, 'UTC',
+    '... except for constructors which assume UTC'
+);
+is( DateTime->from_epoch( epoch => time() )->time_zone->name, 'UTC',
+    '... except for constructors which assume UTC'
+);
+
+my $dt1 = DateTime->new( year => 1970, hour => 1, nanosecond => 100 );
+my $dt2 = DateTime->from_object( object => $dt1 );
+is( $dt2->time_zone->name, 'floating',
+    'Copying DateTime objects from other DateTime objects should retain the timezone'
+);
+
+{
+    local $ENV{DEFAULT_DATETIME_TZ} = 'America/Los_Angeles';
+    is( $dt->time_zone->name, 'floating',
+        'Setting DEFAULT_DATETIME_TZ env should not impact existing objects'
+    );
+    $dt = DateTime->new( year => 2000, month => 2, day => 21 );
+    is( $dt->time_zone->name, $ENV{DEFAULT_DATETIME_TZ},
+        '... but new objects should no longer default to the floating time zone'
+    );
+    is( DateTime->last_day_of_month( year => 2000, month => 2 )
+          ->time_zone->name,
+        $ENV{DEFAULT_DATETIME_TZ},
+        'last_day_of_month time zone also should default to floating'
+    );
+    is( DateTime->from_day_of_year( year => 2000, day_of_year => 212 )
+          ->time_zone->name,
+        $ENV{DEFAULT_DATETIME_TZ},
+        'from_day_of_year time zone also should default to floating'
+    );
+    is( DateTime->now->time_zone->name, 'UTC',
+        '... and constructors which assume UTC should remain unchanged'
+    );
+
+    my $dt1 = DateTime->new( year => 1970, hour => 1, nanosecond => 100 );
+    my $dt2 = DateTime->from_object( object => $dt1 );
+    is( $dt2->time_zone->name, $ENV{DEFAULT_DATETIME_TZ},
+        'Copying DateTime objects from other DateTime objects should retain the timezone'
+    );
+}
+$dt = DateTime->new( year => 2000, month => 2, day => 21 );
+is( $dt->time_zone->name, 'floating',
+    'Default time zone should revert to "floating" when DEFAULT_DATETIME_TZ no longer set'
+);
+
+done_testing();


### PR DESCRIPTION
Setting the DEFAULT_DATETIME_TZ environment variable to an appropriate time
zone will now allow that to be the default rather than "floating". This
addresses the unfortunate issue listed in
https://rt.cpan.org/Ticket/Display.html?id=114064

Per the ticket, I've not included any docs, but do include my heartfelt apologies.