### PR TITLE
From epoch

### DIFF
--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -506,14 +506,14 @@ sub _calc_local_components {
         # quite broken, and would end up rounding some values up, so that -0.5
         # become 0.5 (which is obviously wrong!).
         #
-        # Second, it rounds any decimal values to the nearest millisecond
-        # (1E6). Here's what Christian Hanse, who wrote this patch, says:
+        # Second, it rounds any decimal values to the nearest microsecond
+        # (1E6). Here's what Christian Hansen, who wrote this patch, says:
         #
         #     Perl is typically compiled with NV as a double. A double with a
         #     significand precision of 53 bits can only represent a nanosecond
         #     epoch without loss of precision if the duration from zero epoch
         #     is less than ≈ ±104 days. With microseconds the duration is
-        #     ±104,000 days, which is ~ ±285 years.
+        #     ±104,000 days, which is ≈ ±285 years.
         if ( $p{epoch} =~ /[.eE]/ ) {
             my ( $floor, $nano, $second );
 

--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -514,7 +514,7 @@ sub _calc_local_components {
         #     epoch without loss of precision if the duration from zero epoch
         #     is less than ≈ ±104 days. With microseconds the duration is
         #     ±104,000 days, which is ≈ ±285 years.
-        if ( $p{epoch} =~ /[.eE]/ ) {
+        if ( int $p{epoch} != $p{epoch} ) {
             my ( $floor, $nano, $second );
 
             $floor = $nano = fmod( $p{epoch}, 1.0 );

--- a/t/04epoch.t
+++ b/t/04epoch.t
@@ -127,6 +127,16 @@ use DateTime;
 }
 
 {
+    my $dt = DateTime->from_epoch( epoch => 1609459199.999999 );
+    is(
+        $dt->nanosecond, 999999000,
+        'nanosecond should be 999,999,000 with 1609459199.999999 as epoch'
+    );
+
+    is( $dt->epoch, 1609459199, 'epoch should be 1609459199' );
+}
+
+{
     my $dt = DateTime->from_epoch( epoch => 0.1234567891 );
     is(
         $dt->nanosecond, 123_457_000,


### PR DESCRIPTION
I have changed `->from_epoch` to not rely on the stringified representation of the numeric value when detecting floating point values. This address pull request #6.

--
chansen


